### PR TITLE
security and php7-intl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# OS Generated
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+*.swp
+
+# IDEs
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 .PHONY: all
+
+DOCKER_RUN_TEST_OPTIONS = --user www-data -w /home/www-data --rm
+
 all: php test-php
 
 .PHONY: php
@@ -20,27 +23,27 @@ php:
 
 .PHONY: test-php
 test-php:
-	docker run --rm kreait/php:7.1 bash -c "php -v | grep '7\.1'"
-	docker run --rm kreait/php:7.1-dev bash -c "php -v | grep '7\.1'"
-	docker run --rm kreait/php:7.1-fpm bash -c "php -v | grep '7\.1'"
-	docker run --rm kreait/php:7.1-fpm-dev bash -c "php -v | grep '7\.1'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.1 bash -c "php -v | grep '7\.1'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.1-dev bash -c "php -v | grep '7\.1'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.1-fpm bash -c "php -v | grep '7\.1'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.1-fpm-dev bash -c "php -v | grep '7\.1'"
 
-	docker run --rm kreait/php:7.2 bash -c "php -v | grep '7\.2'"
-	docker run --rm kreait/php:7.2-dev bash -c "php -v | grep '7\.2'"
-	docker run --rm kreait/php:7.2-fpm bash -c "php -v | grep '7\.2'"
-	docker run --rm kreait/php:7.2-fpm-dev bash -c "php -v | grep '7\.2'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.2 bash -c "php -v | grep '7\.2'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.2-dev bash -c "php -v | grep '7\.2'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.2-fpm bash -c "php -v | grep '7\.2'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.2-fpm-dev bash -c "php -v | grep '7\.2'"
 
-	docker run --rm kreait/php:7.3 bash -c "php -v | grep '7\.3'"
-	docker run --rm kreait/php:7.3-dev bash -c "php -v | grep '7\.3'"
-	docker run --rm kreait/php:7.3-fpm bash -c "php -v | grep '7\.3'"
-	docker run --rm kreait/php:7.3-fpm-dev bash -c "php -v | grep '7\.3'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.3 bash -c "php -v | grep '7\.3'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.3-dev bash -c "php -v | grep '7\.3'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.3-fpm bash -c "php -v | grep '7\.3'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.3-fpm-dev bash -c "php -v | grep '7\.3'"
 
-	docker run --rm kreait/php:7.1-dev bash -c "php -v | grep 'Xdebug'"
-	docker run --rm kreait/php:7.1-fpm-dev bash -c "php -v | grep 'Xdebug'"
-	docker run --rm kreait/php:7.2-dev bash -c "php -v | grep 'Xdebug'"
-	docker run --rm kreait/php:7.2-fpm-dev bash -c "php -v | grep 'Xdebug'"
-	docker run --rm kreait/php:7.3-dev bash -c "php -v | grep 'Xdebug'"
-	docker run --rm kreait/php:7.3-fpm-dev bash -c "php -v | grep 'Xdebug'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.1-dev bash -c "php -v | grep 'Xdebug'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.1-fpm-dev bash -c "php -v | grep 'Xdebug'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.2-dev bash -c "php -v | grep 'Xdebug'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.2-fpm-dev bash -c "php -v | grep 'Xdebug'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.3-dev bash -c "php -v | grep 'Xdebug'"
+	docker container run $(DOCKER_RUN_TEST_OPTIONS) kreait/php:7.3-fpm-dev bash -c "php -v | grep 'Xdebug'"
 
 .PHONY: deploy
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-php:
 	docker run --rm kreait/php:7.2-dev bash -c "php -v | grep 'Xdebug'"
 	docker run --rm kreait/php:7.2-fpm-dev bash -c "php -v | grep 'Xdebug'"
 	docker run --rm kreait/php:7.3-dev bash -c "php -v | grep 'Xdebug'"
-    docker run --rm kreait/php:7.3-fpm-dev bash -c "php -v | grep 'Xdebug'"
+	docker run --rm kreait/php:7.3-fpm-dev bash -c "php -v | grep 'Xdebug'"
 
 .PHONY: deploy
 deploy:

--- a/README.md
+++ b/README.md
@@ -25,3 +25,19 @@ The images are automatically re-built and published on a weekly basis.
 | kreait/php:7.3-dev      | [![](https://images.microbadger.com/badges/image/kreait/php:7.3-dev.svg)](https://microbadger.com/images/kreait/php:7.3-dev) |
 | kreait/php:7.3-fpm      | [![](https://images.microbadger.com/badges/image/kreait/php:7.3-fpm.svg)](https://microbadger.com/images/kreait/php:7.3-fpm) |
 | kreait/php:7.3-fpm-dev  | [![](https://images.microbadger.com/badges/image/kreait/php:7.3-fpm-dev.svg)](https://microbadger.com/images/kreait/php:7.3-fpm-dev) |
+
+## Docker Security
+
+All the images are pre-built with a user `www-data` and a group with the same name. Generally there is no need to run containers with `root` privileges, so we advise the following:
+
+**Specify a --user name and set the working directory on docker runs, e.g.:**
+
+```
+    docker run --user www-data -w /home/www-data --rm kreait/php:7.3-dev bash -c "php -v | grep 'Xdebug'"
+```
+
+Confirm it by running:
+
+```
+    docker run --user www-data -w /home/www-data --rm kreait/php:7.3-dev bash -c "id ; env" 
+```

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -6,6 +6,10 @@ FROM alpine:${ALPINE_VERSION} as base
 
 LABEL maintainer="Jérôme Gamez <jerome@kreait.com>"
 
+RUN \
+  sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories && \
+  apk update && apk upgrade
+
 COPY docker /docker/
 
 RUN /docker/scripts/install-packages.sh \

--- a/php/docker/scripts/install-packages.sh
+++ b/php/docker/scripts/install-packages.sh
@@ -12,6 +12,7 @@ apk --no-cache add \
     php7-ftp \
     php7-gd \
     php7-iconv \
+    php7-intl \
     php7-json \
     php7-mbstring \
     php7-mysqlnd \


### PR DESCRIPTION
- added common php7-intl extension to the list
- make docker images more secure/robust
- tell the users how to run these containers as non-root